### PR TITLE
Use HTTPS Instead of SSH for Public Tempo Submodule, Update to First Public Tempo Release

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "Plugins/Tempo"]
 	path = Plugins/Tempo
 	url = https://@github.com:tempo-sim/Tempo.git
-	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "Plugins/Tempo"]
 	path = Plugins/Tempo
-	url = git@github.com:tempo-sim/Tempo.git
-	branch = tempo_submodule
+	url = https://@github.com:tempo-sim/Tempo.git
+	branch = main


### PR DESCRIPTION
Use HTTPS Instead of SSH for Public Tempo Submodule. Also, update Tempo submodule to the first public release