### PR TITLE
Fix Rename Script Bug on Linux and Windows

### DIFF
--- a/Scripts/Rename.sh
+++ b/Scripts/Rename.sh
@@ -8,6 +8,16 @@ if [ -z "$1" ]
     exit
 fi
 
+case "$(uname)" in
+  Darwin*) # macOS
+    # Mac uses BSD sed, which requires a "" after the insert command
+    sed_i=(-i "")
+    ;;
+  *) # Linux and Git Bash on Windows
+    sed_i=(-i)
+    ;;
+esac
+
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 PROJECT_ROOT=$(realpath "$SCRIPT_DIR/..")
 cd "$PROJECT_ROOT"
@@ -17,15 +27,15 @@ NEW_NAME="$1"
 
 # uproject file
 mv "$OLD_NAME.uproject" "$NEW_NAME.uproject"
-sed -i "" "s/$OLD_NAME/$NEW_NAME/g" "$NEW_NAME.uproject"
+sed "${sed_i[@]}" "s/$OLD_NAME/$NEW_NAME/g" "$NEW_NAME.uproject"
 
 cd Source
 
 # Target.cs files
 mv "$OLD_NAME.Target.cs" "$NEW_NAME.Target.cs"
 mv "${OLD_NAME}Editor.Target.cs" "${NEW_NAME}Editor.Target.cs"
-sed -i "" "s/$OLD_NAME/$NEW_NAME/g" "$NEW_NAME.Target.cs"
-sed -i "" "s/$OLD_NAME/$NEW_NAME/g" "${NEW_NAME}Editor.Target.cs"
+sed "${sed_i[@]}" "s/$OLD_NAME/$NEW_NAME/g" "$NEW_NAME.Target.cs"
+sed "${sed_i[@]}" "s/$OLD_NAME/$NEW_NAME/g" "${NEW_NAME}Editor.Target.cs"
 
 # Module folder
 mv "$OLD_NAME" "$NEW_NAME"
@@ -33,7 +43,7 @@ cd "$NEW_NAME"
 
 # Build.cs
 mv "$OLD_NAME.Build.cs" "$NEW_NAME.Build.cs"
-sed -i "" "s/$OLD_NAME/$NEW_NAME/g" "$NEW_NAME.Build.cs"
+sed "${sed_i[@]}" "s/$OLD_NAME/$NEW_NAME/g" "$NEW_NAME.Build.cs"
 
 # Module Source
 mv "Public/$OLD_NAME.h" "Public/$NEW_NAME.h"
@@ -44,6 +54,6 @@ mv "Private/${OLD_NAME}GameMode.cpp" "Private/${NEW_NAME}GameMode.cpp"
 OLD_NAME_CAPS=$(echo "$OLD_NAME" | tr '[:lower:]' '[:upper:]')
 NEW_NAME_CAPS=$(echo "$NEW_NAME" | tr '[:lower:]' '[:upper:]')
 
-find . -type f -name "*.h" -print0 | xargs -0 sed -i "" "s/${OLD_NAME_CAPS}_API/${NEW_NAME_CAPS}_API/g"
-find . -type f -name "*.h" -print0 | xargs -0 sed -i "" "s/$OLD_NAME/$NEW_NAME/g"
-find . -type f -name "*.cpp" -print0 | xargs -0 sed -i "" "s/$OLD_NAME/$NEW_NAME/g"
+find . -type f -name "*.h" -print0 | xargs -0 sed "${sed_i[@]}" "s/${OLD_NAME_CAPS}_API/${NEW_NAME_CAPS}_API/g"
+find . -type f -name "*.h" -print0 | xargs -0 sed "${sed_i[@]}" "s/$OLD_NAME/$NEW_NAME/g"
+find . -type f -name "*.cpp" -print0 | xargs -0 sed "${sed_i[@]}" "s/$OLD_NAME/$NEW_NAME/g"


### PR DESCRIPTION
@Mdclaudio noticed that the rename script wasn't working on Windows. The reason is that the sed used by Mac is BSD sed, not GNU sed (like on Linux or Git Bash on Windows) and is slightly different. For BSD sed we need to use `sed -i ""`. And for GNU sed only `sed -i`.